### PR TITLE
Remove unnecessary runtime dependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "config-weaver",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "description": "Simple configuration mechanism allowing infrastructure engineeers to override values via environment variables",
   "main": "./src/config.js",
   "scripts": {
@@ -13,7 +13,6 @@
   "author": "David Sinclair",
   "license": "MIT",
   "devDependencies": {
-    "fs": "0.0.2",
     "grunt": "^0.4.5",
     "grunt-contrib-clean": "~0.5.0",
     "grunt-contrib-jasmine": "^0.6.5",
@@ -21,10 +20,8 @@
     "grunt-istanbul": "^0.3.0",
     "grunt-jasmine-node": "^0.2.1",
     "grunt-sonar-runner": "^2.3.1",
-    "js-yaml": "^3.2.2",
     "load-grunt-config": "^0.13.1",
-    "load-grunt-tasks": "^0.6.0",
-    "optimist": "^0.6.1"
+    "load-grunt-tasks": "^0.6.0"
   },
   "bugs": {
     "url": "https://github.com/davidsinclair/config-weaver/issues"
@@ -35,17 +32,7 @@
   },
   "dependencies": {
     "fs": "^0.0.2",
-    "grunt": "^0.4.5",
-    "grunt-contrib-clean": "^0.5.0",
-    "grunt-istanbul": "^0.3.0",
-    "grunt-jasmine-node": "^0.2.1",
-    "grunt-contrib-jshint": "^0.10.0",
-    "grunt-contrib-jasmine": "^0.6.5",
-    "grunt-sonar-runner": "^2.3.1",
-    "js-yaml": "^3.2.2",
-    "load-grunt-config": "^0.13.1",
-    "load-grunt-tasks": "^0.6.0",
-    "optimist": "^0.6.1"
+    "js-yaml": "^3.2.2"
   },
   "keywords": [
     "config",

--- a/src/config.js
+++ b/src/config.js
@@ -7,11 +7,12 @@ module.exports = {
             if (key.indexOf(prefix) === 0) {
                 var val = env[key];
 
-                // strip off the prexif and then tokenize by '_'
-                key = key.substring(prefix.length+1);// +1 for the _
+                // Strip off the prefix and then tokenize by '_'.
+                // Add 1 to prefix length for the '_' character.
+                key = key.substring(prefix.length + 1);
 
                 var parts = key.split('_');
-        
+
                 // set the value
                 var place = config;
 
@@ -36,15 +37,14 @@ module.exports = {
 
     // get a list of env vars to use to override these slots
     showVars : function (config, prefix) {
-        var path = prefix;
         var that = this;
         Object.keys(config).forEach(function(prop){
             if (config[prop] instanceof Object) {
-                that.showVars(config[prop], prefix+'_'+prop)
+                that.showVars(config[prop], prefix+'_'+prop);
             } else {
                 console.log(prefix+'_'+prop+'='+config[prop]);
             }
-        }); 
+        });
     },
 
     // get the config for the module.  This is the result of applying all environment


### PR DESCRIPTION
This reduces the size of the node_modules/config_weaver directory by about 48MB in projects that use config-weaver.
